### PR TITLE
Fix variable usage in echo

### DIFF
--- a/Hello.php
+++ b/Hello.php
@@ -1,2 +1,2 @@
 $hello = "Hello World"
-echoo #hello;
+echoo $hello;


### PR DESCRIPTION
The `hello` variable was used with a hash instead of a dollar sign. Corrected this mistake.